### PR TITLE
Fix TAP IP fragmentation issue

### DIFF
--- a/tun_tap/kill_modem.sh
+++ b/tun_tap/kill_modem.sh
@@ -2,3 +2,6 @@
 
 PID=$(pidof modemd)
 kill -9 $PID 
+
+PID=$(pidof wpa_supplicant)
+kill -9 $PID 

--- a/tun_tap/modemd.c
+++ b/tun_tap/modemd.c
@@ -37,7 +37,7 @@
 #define PADDING_SIZE		12
 #define TX_BUF_SIZE			HEADER_DATA_SIZE + HEADER_FRAME_SIZE + MTU + PADDING_SIZE
 #define RX_BUF_SIZE			HEADER_FRAME_SIZE + MTU + PADDING_SIZE + CRC_SIZE
-#define ETH_HEADER_SIZE     10
+#define ETH_HEADER_SIZE     18
 #define MTU_IP              MTU-ETH_HEADER_SIZE
 
 extern char 	*optarg;

--- a/tun_tap/restart_modem_gui.sh
+++ b/tun_tap/restart_modem_gui.sh
@@ -75,5 +75,5 @@ cat /sys/kernel/debug/iio/iio:device3/direct_reg_access
 
 
 /usr/local/bin/modemd -a $ip -m $subnet -d $delay & 
-#/usr/local/bin/en_macsec.sh
+/usr/local/bin/en_macsec.sh
 

--- a/wpa-supplicant/install.sh
+++ b/wpa-supplicant/install.sh
@@ -44,6 +44,9 @@ cp wpa_cli wpa_supplicant /usr/local/bin
 chmod 777 /usr/local/bin/wpa_cli
 chmod 777 /usr/local/bin/wpa_supplicant
 
+#need to call wpa_supplicant once before relinking libnl libraries below
+wpa_supplicant -h
+
 cd /lib/arm-linux-gnueabihf/
 rm libnl-3.so.200
 ln -s /usr/local/lib/libnl-3.so.200 libnl-3.so.200


### PR DESCRIPTION
The TAP interface did not work because the extra overhead from Ethernet reduced the effective MTU. The MTU of the IP layer defaults to 1500 bytes which is all that our MAC can handle, leaving no room for Ethernet overhead. When fragmenting IP packets larger than MTU, the fragmentation offset of the fragmented packet would be set incorrectly when using TAP. Reducing the MTU of the adi_radio device to allow for the Ethernet overhead allows fragmented IP packets to be sent correctly.

This update lowers the MTU of adi_radio by 10 bytes and also enables TAP instead of TUN and also enables encryption.