### PR TITLE
rfsom-box-gui: Add Battery SoC and Charger Status

### DIFF
--- a/bin/batt_man.sh
+++ b/bin/batt_man.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+dev=/sys/class/power_supply/ltc2942
+
+while true; do
+	voltage=`echo "scale=5;$(<$dev/voltage_now) / 1000000" | bc`
+	status=`i2cget -y 0 0x14 0xB`
+
+	case $(($status & 0x7)) in
+		0)  mode="Off" ;;
+		1)  mode="Trickle Charge" ;;
+		2)  mode="Fast Charge Constant Current" ;;
+		3)  mode="Fast Charge Constant Volatge" ;;
+		4)  mode="Charge Complete" ;;
+		5)  mode="LDO mode" ;;
+		6)  mode="Charge Timer Expired" ;;
+		7)  mode="Battery Detection" ;;
+	esac
+
+	case $(($status & 0x7)) in
+		0)  soc=`echo "p=160.96*$voltage-549.82;scale=0; if (p > 100) {100} else if (p < 0) {0} else {p/1}" | bc` ;;
+		*)  soc=`echo "if ($voltage < 3.72) {p=11.3472 * ($voltage - 3.27)} else {p=188.717*$voltage-697};scale=0;if (p > 100) {100} else if (p < 0) {0} else {p/1}" | bc` ;;
+	esac
+
+	#echo $voltage $mode $soc%
+
+	echo "$voltage" > /tmp/rfsom_batt_volatge
+	echo "$soc%" > /tmp/rfsom_batt_soc
+	echo "$mode" > /tmp/rfsom_batt_mode
+
+	if [ "$mode" == "Charge Complete" ] && [ "$previous_mode" == "Fast Charge Constant Volatge" ]; then
+		echo 3200000 > $dev/charge_now
+	fi
+
+	previous_mode=$mode
+
+	if [ $(echo "$voltage < 3.3" | bc -l) == "1" ] && [ "$mode" == "Off" ]; then
+		echo 0 > $dev/charge_now
+		poweroff
+	fi
+
+	sleep 10
+done

--- a/bin/rfsom-box-gui-start.sh
+++ b/bin/rfsom-box-gui-start.sh
@@ -14,6 +14,7 @@ if [ $? -eq 0 ]; then
 	    ;;
 	esac
 	sudo service lightdm stop;
+	/usr/local/bin/batt_man.sh &
 	gpsd -n /dev/ttyPS1;
 	echo 972 > /sys/class/gpio/export;
 	echo 973 > /sys/class/gpio/export;

--- a/rfsom-box-gui.pro
+++ b/rfsom-box-gui.pro
@@ -30,6 +30,7 @@ scripts.files += ./bin/start_stream.sh
 scripts.files += ./bin/recv_stream.sh
 scripts.files += ./bin/start_plot.sh
 scripts.files += ./bin/enc-onoff.sh
+scripts.files += ./bin/batt_man.sh
 scripts.files += ./tun_tap/restart_modem_gui.sh
 scripts.files += ./tun_tap/en_macsec.sh
 scripts.files += ./tun_tap/modemd
@@ -48,6 +49,7 @@ unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/restart_modem_gui.sh;
 unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/en_macsec.sh;
 unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/get_gmap.sh;
 unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/enc-onoff.sh;
+unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/batt_man.sh;
 unix:permission.extra += chmod 777 $$INSTALL_LOCATION/bin/modemd
 
 INSTALLS += target scripts share permission

--- a/share/rfsom-box-gui/landing.json
+++ b/share/rfsom-box-gui/landing.json
@@ -22,7 +22,7 @@
     {
       "description": "",
       "timer": 2,
-      "cmd_read": "echo 100%",
+      "cmd_read": "cat /tmp/rfsom_batt_soc",
       "iconSize": 16,
       "icon": "../share/rfsom-box-gui/icons/005-technology.png"
     },

--- a/share/rfsom-box-gui/launcher.json
+++ b/share/rfsom-box-gui/launcher.json
@@ -439,6 +439,24 @@
           "cmd": "/usr/local/bin/read_pss -text"
         },
         {
+          "description": "Charger Status",
+          "type": "cmd_read",
+          "timer": 0,
+          "cmd": "cat /tmp/rfsom_batt_mode"
+        },
+        {
+          "description": "Battery SoC (voltage)",
+          "type": "cmd_read",
+          "timer": 0,
+          "cmd": "cat /tmp/rfsom_batt_soc"
+        },
+        {
+          "description": "Battery SoC (charge)",
+          "type": "cmd_read",
+          "timer": 0,
+          "cmd": "echo \"scale=0;p=`cat /sys/class/power_supply/ltc2942/charge_now` / 32000; if (p > 100) 100 else if (p < 0) 0 else p\" | bc"
+        },
+        {
           "description": "Battery Volatge (V)",
           "type": "cmd_read",
           "timer": 0,


### PR DESCRIPTION
There are two different algorithms for computing SoC. One based on
Voltage the other uses the Coulomb Counter. The landing page currently
uses the Cell Voltage based approach. After some further evaluation
we may switch it to the charge based. The charge based SoC indication
requires calibration. This is done by either running the battery empty or
charging it until the charger turns off.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>