### PR TITLE
batt_man.sh: Add support for ADP5061

### DIFF
--- a/bin/batt_man.sh
+++ b/bin/batt_man.sh
@@ -12,9 +12,17 @@ if [ "$(id -u)" != "0" ] ; then
         exit 1
 fi
 
-if [ $(i2cdetect -y 0 0x14 0x14 | grep -e "^10:" | grep 14 | wc -l) -eq "0" ] ; then
+if [ $(i2cdetect -y 0 0x14 0x14 | grep -e "^10:" | grep -e '14\|UU' | wc -l) -eq "0" ] ; then
 	echo "Could not find ADP5061"
 	exit 1
+fi
+
+dev_adp5061=/sys/class/power_supply/adp5061
+
+adp5061_installed=1
+if [ ! -f $dev_adp5061/voltage_max ] ; then
+	adp5061_installed=0
+	echo adp5061 not installed
 fi
 
 me="$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")"
@@ -30,22 +38,23 @@ previous_mode=foo
 while true; do
 	voltage=`echo "scale=5;$(cat $dev/voltage_now) / 1000000" | bc`
 	# Get the ADP5061 Linear Battery Charger status
-	# this is a super dirty hack, since a driver doesn't exist yet.
-	status=`i2cget -y 0 0x14 0xB`
+	if [ $adp5061_installed -eq 1 ] ; then
+		status=$(cat $dev_adp5061/status)
+		mode="$status"
+	else
+		# this is a super dirty hack, since a driver is not installed
+		status=`i2cget -y 0 0x14 0xB`
+		case $(($status & 0x7)) in
+			0)  mode="Not charging" ;;
+			1 | 2 | 3)  mode="Charging" ;;
+			4)  mode="Full" ;;
+			6)  mode="Discharging" ;;
+			*)  mode="Unknown" ;;
+		esac
+	fi
 
-	case $(($status & 0x7)) in
-		0)  mode="Off" ;;
-		1)  mode="Trickle Charge" ;;
-		2)  mode="Fast Charge Constant Current" ;;
-		3)  mode="Fast Charge Constant Voltage" ;;
-		4)  mode="Charge Complete" ;;
-		5)  mode="LDO mode" ;;
-		6)  mode="Charge Timer Expired" ;;
-		7)  mode="Battery Detection" ;;
-	esac
-
-	case $(($status & 0x7)) in
-		0)  soc=`echo "p=160.96*$voltage-549.82;scale=0; if (p > 100) {100} else if (p < 0) {0} else {p/1}" | bc` ;;
+	case "$mode" in
+		"Not charging") soc=`echo "p=160.96*$voltage-549.82;scale=0; if (p > 100) {100} else if (p < 0) {0} else {p/1}" | bc` ;;
 		*)  soc=`echo "if ($voltage < 3.72) {p=11.3472 * ($voltage - 3.27)} else {p=188.717*$voltage-697};scale=0;if (p > 100) {100} else if (p < 0) {0} else {p/1}" | bc` ;;
 	esac
 
@@ -55,15 +64,15 @@ while true; do
 	echo "$soc%" > /tmp/rfsom_batt_soc
 	echo "$mode" > /tmp/rfsom_batt_mode
 
-	if [ "$mode" = "Charge Complete" -a \
-	     "$previous_mode" = "Fast Charge Constant Voltage" ]; then
+	if [ "$mode" = "Full" -a \
+	     "$previous_mode" = "Charging" ]; then
 		echo 3200000 > $dev/charge_now
 	fi
 
 	previous_mode=$mode
 
 	if [ $(echo "$voltage < 3.3" | bc -l) -eq "1" -a \
-	     "$mode" = "Off" ]; then
+	     "$mode" = "Not charging" ]; then
 		echo 0 > $dev/charge_now
 		poweroff
 	fi


### PR DESCRIPTION
This patch adds support for the new ADP5061 driver.

If the driver is installed, then the charger status is read by using the
power_supply status property routine. The values returned by this attibute
are Charging, Not charging, Full, Discharging and Unknown.

If the driver is not installed, then the status is retrieved via the i2cget
routine. The values returned were grouped to be consistent with the
power_supply status attribute.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>